### PR TITLE
fix: remove legacy prestart script to fix issues with yarn start.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "yup": "^0.29.3"
   },
   "scripts": {
-    "prestart": "yarn codegen",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --passWithNoTests",


### PR DESCRIPTION
Issue: master brunch don't run from the box. Problem in yarn generate script.
If i correctly understand this is was script for graphql  generation but function generate is not available now, so i suppose we can remove it to enable correct run process for backoffice in master from box.